### PR TITLE
Fix disc detection & PS2 handling (CUE→BIN sniffing, safer extraction, fewer false positives)

### DIFF
--- a/chdtool.sh
+++ b/chdtool.sh
@@ -892,19 +892,37 @@ detect_disc_type() {
     # -----------------
 
     # Sniff the header before checking extensions
+    # --- UPDATED SNIFF LOGIC WITH DEBUGGING ---
     local sniff_target="$img"
-    # If it's a CUE, we need to sniff the first referenced file instead (usually BIN) to get the real disc type
     if [[ "$ext" == "cue" ]]; then
-        # Grab the first filename inside the CUE (usually the main data track)
+        local raw_bin_name
+        raw_bin_name=$(awk -F'"' '/^FILE/{print $2; exit}' "$img")
+        
         local bin_path
-        bin_path="$(dirname "$img")/$(awk -F'"' '/^FILE/{print $2; exit}' "$img")"
-        [[ -f "$bin_path" ]] && sniff_target="$bin_path"
+        bin_path="$(dirname "$img")/$raw_bin_name"
+        
+        log DEBUG "DEBUG: CUE refers to file: [$raw_bin_name]"
+        log DEBUG "DEBUG: Full resolved bin_path: [$bin_path]"
+
+        if [[ -f "$bin_path" ]]; then
+            log DEBUG "DEBUG: Successfully found BIN file. Switching sniff_target."
+            sniff_target="$bin_path"
+        else
+            log DEBUG "DEBUG: FAILED to find BIN file at that path."
+            log DEBUG "DEBUG: Directory contents of $(dirname "$img"): $(ls -m "$(dirname "$img")")"
+        fi
     fi
 
     #2. Console Fingerprinting
     # Reading the first 64KB covers Volume Descriptors and Boot Headers
     local header
     header=$(head -c 65535 "$sniff_target" 2>/dev/null | tr -d '\0')
+
+    # Check for PS2 specifically in debug
+    if [[ "$header" == *"PLAYSTATION 2"* ]]; then
+        log DEBUG "DEBUG: 'PLAYSTATION 2' string found in header of $(basename "$sniff_target")"
+    fi
+    # ------------------------------------------
 
     case "$header" in
         *"PLAYSTATION 2"*|*"NTSC-U/C PS2 DVD"*) echo "ps2"; return 0 ;;

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -975,7 +975,30 @@ convert_disc_file() {
 
     local subcmd icon
     case "$disc_type" in
-        ps2|psp|dvd)
+        ps2)
+            # PS2 is the special case; Hunk is ALWAYS 2048, but command depends on size
+            log DEBUG "PS2 image detected, checking size to determine if DVD structure is likely"
+            local sz
+            sz=$(get_file_size "$file")
+            hunk_size=2048
+            if (( sz >= 1000000000 )); then
+                log DEBUG "Large PS2 image suggests DVD structure, CHDMAN_HAS_CREATEDVD=$CHDMAN_HAS_CREATEDVD"
+                if [[ "$CHDMAN_HAS_CREATEDVD" == true ]]; then
+                    log DEBUG "Using createdvd for large PS2 image"
+                    subcmd="createdvd"
+                    icon="📀"
+                else
+                    log WARN "⚠️ PS2 DVD detected but chdman lacks 'createdvd'. Skipping $file."
+                    failures=$((failures + 1))
+                    return 1
+                fi
+            else
+                log DEBUG "Smaller PS2 image suggests CD structure, using createcd"
+                subcmd="createcd"
+                icon="💿"
+            fi
+            ;;
+        psp|dvd)
             log DEBUG "DVD detected, CHDMAN_HAS_CREATEDVD=$CHDMAN_HAS_CREATEDVD"
             if [[ "$CHDMAN_HAS_CREATEDVD" == true ]]; then
                 subcmd="createdvd"
@@ -988,6 +1011,7 @@ convert_disc_file() {
             fi
             ;;
         ps1|dreamcast|segacd|saturn|cd)
+            log DEBUG "CD-type image detected, using createcd"
             subcmd="createcd"
             hunk_size=2448 # CD-ROMs use 2352-byte raw sectors but chdman createcd expects 2448 to include subchannel data for full disc preservation
             icon="💿"
@@ -1137,6 +1161,7 @@ process_input() {
 
             log DEBUG "🧹 Flushing extraction buffers to free up RAM..."
             sync
+            sleep 1
 
             read -r -a disc_find_expr <<< "$(build_find_expr "${disc_exts[@]}")"
             mapfile -d '' -t disc_files < <(find "$temp_dir" -type f \( "${disc_find_expr[@]}" \) -print0)

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -886,22 +886,25 @@ detect_disc_type() {
     #1. Size-based "hard limits"
     # If it's > 1GB, it's a DVD/PS2 regardless of what the header says (some PS2 games have weird headers that look like CDs)
     local is_large_disc=false
-    if [[ -n "$sz" ]] && (( sz >= 1000000000 )); then
-        is_large_disc=true
-    fi
+    (( sz >= 1000000000 )) && is_large_disc=true
     # --- DEBUGGING ---
     log DEBUG "is_large_disc for $(basename "$img"): $is_large_disc (size: $sz bytes)"
     # -----------------
 
-    #2. Immediate CD extensions - CUE/CCD/GDI are CD-type by definition
-    case "$ext" in
-        cue|ccd|gdi) echo "cd"; return 0 ;;
-    esac
+    # Sniff the header before checking extensions
+    local sniff_target="$img"
+    # If it's a CUE, we need to sniff the first referenced file instead (usually BIN) to get the real disc type
+    if [[ "$ext" == "cue" ]]; then
+        # Grab the first filename inside the CUE (usually the main data track)
+        local bin_path
+        bin_path="$(dirname "$img")/$(awk -F'"' '/^FILE/{print $2; exit}' "$img")"
+        [[ -f "$bin_path" ]] && sniff_target="$bin_path"
+    fi
 
-    #3. Console Fingerprinting
+    #2. Console Fingerprinting
     # Reading the first 64KB covers Volume Descriptors and Boot Headers
     local header
-    header=$(head -c 65535 "$img" 2>/dev/null | tr -d '\0')
+    header=$(head -c 65535 "$sniff_target" 2>/dev/null | tr -d '\0')
 
     case "$header" in
         *"PLAYSTATION 2"*|*"NTSC-U/C PS2 DVD"*) echo "ps2"; return 0 ;;
@@ -918,6 +921,11 @@ detect_disc_type() {
         *"SEGA SEGAKATANA"*) echo "dreamcast"; return 0 ;;
         *"SEGA SEGASATURN"*) echo "saturn"; return 0 ;;
         *"PSP GAME"*|*"UMD VIDEO"*) echo "psp"; return 0 ;;
+    esac
+
+    #3. Immediate CD extensions - CUE/CCD/GDI are CD-type by definition
+    case "$ext" in
+        cue|ccd|gdi) echo "cd"; return 0 ;;
     esac
 
     #4. UDF/ISO logic fallback

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -1153,11 +1153,28 @@ process_input() {
             temp_dir="$(mktemp -d -p "$TMPDIR" "chdconv_$(basename "$input_file" ".${ext}")_XXXX")"
             log INFO "📦 Extracting $input_file to $temp_dir"
             TEMP_DIRS+=("$temp_dir")
+            local extraction_exit=0
             case "$ext" in
-                zip) unzip -qq "$input_file" -d "$temp_dir" ;;
-                rar) unrar x -o+ "$input_file" "$temp_dir" >/dev/null ;;
-                7z|7zip) 7z x -y -o"$temp_dir" "$input_file" >/dev/null ;;
+                zip)
+                    unzip -qq "$input_file" -d "$temp_dir"
+                    extraction_exit=$?
+                    ;;
+                rar)
+                    unrar x -o+ "$input_file" "$temp_dir" >/dev/null
+                    extraction_exit=$?
+                    ;;
+                7z|7zip)
+                    7z x -y -o"$temp_dir" "$input_file" >/dev/null
+                    extraction_exit=$?
+                    ;;
             esac
+
+            # Strict validation: Abort if the extraction tool retrned an error code, which likely means the archive is corrupted or password-protected.
+            if [[ $extraction_exit -ne 0 ]]; then
+                log ERROR "❌ Extraction failed for $input_file (Exit code: $extraction_exit). Skipping."
+                failures=$((failures + 1))
+                return 1
+            fi
 
             log DEBUG "🧹 Flushing extraction buffers to free up RAM..."
             sync

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -874,6 +874,7 @@ validate_cue_file() {
 }
 
 detect_disc_type() {
+    log DEBUG "DEBUG: Starting detection for: $1"
     local img="$1"
     local ext
     ext="${img##*.}"; ext="${ext,,}"

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -879,11 +879,19 @@ detect_disc_type() {
     ext="${img##*.}"; ext="${ext,,}"
     local sz
     sz=$(get_file_size "$img" 2>/dev/null || echo 0)
-    
+    # --- DEBUGGING ---
+    log DEBUG "sz value for $(basename "$img"): [${sz}]"
+    # -----------------
+
     #1. Size-based "hard limits"
     # If it's > 1GB, it's a DVD/PS2 regardless of what the header says (some PS2 games have weird headers that look like CDs)
     local is_large_disc=false
-    (( sz >= 1000000000 )) && is_large_disc=true
+    if [[ -n "$sz" ]] && (( sz >= 1000000000 )); then
+        is_large_disc=true
+    fi
+    # --- DEBUGGING ---
+    log DEBUG "is_large_disc for $(basename "$img"): $is_large_disc (size: $sz bytes)"
+    # -----------------
 
     #2. Immediate CD extensions - CUE/CCD/GDI are CD-type by definition
     case "$ext" in
@@ -926,17 +934,11 @@ detect_disc_type() {
         fi
 
         # Size heuristic: ≥ ~1 GB → likely DVD; otherwise CD
-        local sz
-        sz=$(get_file_size "$img")
-        (( sz >= 1000000000 )) && { echo "dvd"; return 0; }
+        [[ "$is_large_disc" == true ]] && { echo "dvd"; return 0; }
     fi
 
-    # Unknown extension → default to CD (safe for createcd)
-    if [[ "$is_large_disc" == true ]]; then
-        echo "dvd"; return 0
-    else
-        echo "cd"; return 0
-    fi
+    #5 Final fallback: Unknown extension → default to CD (safe for createcd)
+    [[ "$is_large_disc" == true ]] && echo "dvd" || echo "cd"
 }
 
 convert_disc_file() {


### PR DESCRIPTION
## Fix disc detection & PS2 handling (CUE→BIN sniffing, safer extraction, fewer false positives)

### What / Why
This PR tightens up **disc-type detection** and **PS2 CD/DVD conversion logic** so we:
- classify images more reliably (especially CUE/BIN sets),
- avoid kicking `chdman` against bad or incomplete extracts,
- and reduce edge cases where the wrong `chdman` subcommand or hunk alignment is used.

### Key changes

#### CUE → BIN sniffing for accurate fingerprinting
When the input is a `.cue`, `detect_disc_type()` now resolves the first referenced `FILE` entry and inspects the actual data track instead of short-circuiting on the extension.

This allows proper console detection for CUE/BIN sets rather than assuming generic CD.

#### Disc size detection refactor
File size detection is now consolidated into a single `sz` lookup with a derived `is_large_disc` flag.

Additional DEBUG logs were added so that detection decisions are traceable in logs.

#### PS2 CD/DVD conversion correctness + stability
PS2 images are now handled as a special case:

- **Hunk size remains 2048** (required for PS2 compatibility)
- **Subcommand is chosen based on size**
  - smaller images → `createcd`
  - larger images → `createdvd` (when supported)

A short delay was added before invoking `chdman` to avoid occasional race conditions on fast or virtualized storage.

#### Strict archive extraction validation
Archive extraction now explicitly checks exit codes from:
- `unzip`
- `unrar`
- `7z`

If extraction fails, the script aborts early rather than attempting conversion on incomplete or corrupt files.

#### Improved debugging for CUE resolution
Additional debug logging now shows:
- the referenced BIN filename
- the resolved path
- confirmation when PS2 headers are detected

This makes diagnosing unusual CUE layouts much easier.

### Behaviour changes
- `.cue` files are **no longer automatically treated as generic CD images**.  
  Detection now inspects the referenced BIN track instead.

- Corrupt or password-protected archives now **fail fast with clearer logging** instead of producing confusing downstream conversion errors.

### Testing
- [ ] CUE/BIN set: ensure BIN is resolved and sniffed; detection matches expected console
- [ ] PS2 CD-sized image: uses `createcd` with 2048 hunks
- [ ] PS2 DVD-sized image: uses `createdvd` when supported
- [ ] Corrupt ZIP/RAR/7Z: extraction fails fast with clear logging
- [ ] Normal ISO and ZIP workflows complete successfully