### PR TITLE
fix: make source deletion transactional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@ SHELL := /usr/bin/env bash
 # Path to your script; override with: make test SCRIPT=./path/to/script.sh
 SCRIPT ?= ./chdtool.sh
 
-.PHONY: test test-m3u test-m3u-single test-logging test-setup clean changelog changelog-tag
+.PHONY: test test-m3u test-m3u-single test-transactional-source-deletion test-logging test-setup clean changelog changelog-tag
 
-test: test-setup test-m3u test-m3u-single test-logging
+test: test-setup test-m3u test-m3u-single test-transactional-source-deletion test-logging
 
 test-setup:
 	chmod +x tests/bin/chdman
 	chmod +x tests/bin/unrar
 	-chmod +x tests/bin/7z
-	chmod +x tests/test_m3u.sh tests/test_m3u_single.sh
+	chmod +x tests/test_m3u.sh tests/test_m3u_single.sh tests/test_transactional_source_deletion.sh
 	@if [ -f tests/test_logging.sh ]; then chmod +x tests/test_logging.sh; fi
 
 test-m3u:
@@ -19,6 +19,9 @@ test-m3u:
 
 test-m3u-single:
 	SCRIPT=$(SCRIPT) bash tests/test_m3u_single.sh
+
+test-transactional-source-deletion:
+	SCRIPT=$(SCRIPT) bash tests/test_transactional_source_deletion.sh
 
 test-logging:
 	@if [ -f tests/test_logging.sh ]; then \

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -1266,17 +1266,17 @@ process_input() {
         fi
     fi
 
-    # If all expected CHDs already exist and verify, remove original and done
+    # If all expected CHDs already exist and verify, generate the complete-set
+    # playlist before treating source removal as the final action.
     if [[ "$input_failed" != true ]] && verify_chds "$outdir" "${expected_chds[@]}"; then
         log INFO "✅ All expected CHDs verified for $input_file"
-        _remove_input_if_allowed
-        # Per-iteration M3U generation for already-present sets
         if [[ ${#expected_chds[@]} -gt 0 ]]; then
             local chd_base
             chd_base="$(basename "${expected_chds[0]}" .chd)"
             log DEBUG "🔤 Raw base name: $chd_base"
             maybe_generate_m3u_for "$chd_base" "$outdir"
         fi
+        _remove_input_if_allowed
         return 0
     fi
 
@@ -1409,8 +1409,6 @@ process_input() {
                 chds_created=$((chds_created + 1))
             done
 
-            _remove_input_if_allowed
-            
             for chd in "${expected_chds[@]}"; do
                 if [[ -f "$outdir/$chd" ]]; then
                     archive_chd_size=$((archive_chd_size + $(get_file_size "$outdir/$chd")))
@@ -1436,17 +1434,27 @@ process_input() {
     fi
 
     if [[ "$input_failed" == true ]]; then
+        log WARN "⚠️ Not all expected members converted successfully for $input_file, keeping original"
         _return_failed_input
         return 1
     fi
 
-    # Per-iteration M3U generation (only on success)
+    # Source deletion is the final action. First require the complete expected
+    # final CHD set to exist and pass verification, then generate its playlist.
+    if ! verify_chds "$outdir" "${expected_chds[@]}"; then
+        log WARN "⚠️ Complete final CHD set failed verification for $input_file, keeping original"
+        _return_failed_input
+        return 1
+    fi
+
     if [[ ${#expected_chds[@]} -gt 0 ]]; then
         local chd_base
         chd_base="$(basename "${expected_chds[0]}" .chd)"
         log DEBUG "🔤 Raw base name: $chd_base"
         maybe_generate_m3u_for "$chd_base" "$outdir"
     fi
+
+    _remove_input_if_allowed
 
     return 0
 }

--- a/tests/bin/chdman
+++ b/tests/bin/chdman
@@ -11,9 +11,22 @@ case "$1" in
     exit 0
     ;;
   createcd|createdvd)
-    # not used in the test; if called, fail fast so we notice
-    echo "stub chdman: create not supported in test" >&2
-    exit 2
+    input=""
+    output=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -i) input="$2"; shift 2 ;;
+        -o) output="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ -n "${CHDMAN_FAIL_INPUT:-}" && "$input" == *"$CHDMAN_FAIL_INPUT"* ]]; then
+      echo "stub chdman: requested failure for $input" >&2
+      exit 2
+    fi
+    : > "$output"
+    echo "Compressing, 100% complete (ratio=50%)" >&2
+    exit 0
     ;;
   *)
     echo "stub chdman: unknown args: $*" >&2

--- a/tests/test_transactional_source_deletion.sh
+++ b/tests/test_transactional_source_deletion.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${SCRIPT:-$REPO_ROOT/chdtool.sh}"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+
+export PATH="$REPO_ROOT/tests/bin:$PATH"
+export PROGRESS_STYLE=none
+export LOG_DEST=console
+export LOG_LEVEL_THRESHOLD=ERROR
+export CHDMAN_FAIL_INPUT="Transactional Game (Disc 2).iso"
+
+ARCHIVE="$FIX/transactional-game.zip"
+(
+  cd "$FIX"
+  : > "Transactional Game (Disc 1).iso"
+  : > "Transactional Game (Disc 2).iso"
+  zip -q "$(basename "$ARCHIVE")" \
+    "Transactional Game (Disc 1).iso" \
+    "Transactional Game (Disc 2).iso"
+  rm -f "Transactional Game (Disc 1).iso" "Transactional Game (Disc 2).iso"
+)
+
+# Issue #30 owns the overall process exit status; this test asserts filesystem effects only.
+bash "$SCRIPT" "$FIX" || true
+
+if [[ ! -f "$ARCHIVE" ]]; then
+  echo "FAIL: source archive was deleted after a partial conversion" >&2
+  exit 1
+fi
+
+if [[ -f "$FIX/Transactional Game.m3u" ]]; then
+  echo "FAIL: M3U was generated for an incomplete CHD set" >&2
+  exit 1
+fi
+
+if [[ ! -f "$FIX/Transactional Game (Disc 1).chd" ]]; then
+  echo "FAIL: successfully verified Disc 1 CHD was not finalised" >&2
+  exit 1
+fi
+
+if [[ -f "$FIX/Transactional Game (Disc 2).chd" ]]; then
+  echo "FAIL: failed Disc 2 unexpectedly produced a final CHD" >&2
+  exit 1
+fi
+
+echo "PASS: partial archive conversion retains source and omits M3U"


### PR DESCRIPTION
## Summary

- make source deletion the final transactional action for each input
- retain the source when any expected archive member fails conversion
- verify the complete final CHD set before generating an M3U or deleting the source
- add a black-box regression test for a partial two-disc archive conversion

## Root cause

The conversion flow verified only the successfully produced temporary CHDs and deleted the source immediately after finalising them. If a later archive member failed conversion, an incomplete output set could therefore replace the original archive.

## Impact

Successfully converted and verified CHDs may still be finalised, but the original source remains available unless every expected final CHD exists and verifies. Complete-set M3Us are generated only after that postcondition succeeds. `--keep-originals` and dry-run behaviour are preserved.

Closes #27.

## Validation

- `make test`
- `shellcheck chdtool.sh tests/*.sh tests/bin/chdman tests/bin/unrar tests/bin/7z`
- `git diff --check`
