### PR TITLE
fix: use unique tracked temporary CHD outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,16 @@ SHELL := /usr/bin/env bash
 # Path to your script; override with: make test SCRIPT=./path/to/script.sh
 SCRIPT ?= ./chdtool.sh
 
-.PHONY: test test-m3u test-m3u-single test-transactional-source-deletion test-logging test-setup clean changelog changelog-tag
+.PHONY: test test-m3u test-m3u-single test-transactional-source-deletion test-temporary-chd-cleanup test-logging test-setup clean changelog changelog-tag
 
-test: test-setup test-m3u test-m3u-single test-transactional-source-deletion test-logging
+test: test-setup test-m3u test-m3u-single test-transactional-source-deletion test-temporary-chd-cleanup test-logging
 
 test-setup:
 	chmod +x tests/bin/chdman
 	chmod +x tests/bin/unrar
 	-chmod +x tests/bin/7z
 	chmod +x tests/test_m3u.sh tests/test_m3u_single.sh tests/test_transactional_source_deletion.sh
+	chmod +x tests/test_temporary_chd_cleanup.sh
 	@if [ -f tests/test_logging.sh ]; then chmod +x tests/test_logging.sh; fi
 
 test-m3u:
@@ -22,6 +23,9 @@ test-m3u-single:
 
 test-transactional-source-deletion:
 	SCRIPT=$(SCRIPT) bash tests/test_transactional_source_deletion.sh
+
+test-temporary-chd-cleanup:
+	SCRIPT=$(SCRIPT) bash tests/test_temporary_chd_cleanup.sh
 
 test-logging:
 	@if [ -f tests/test_logging.sh ]; then \

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -736,6 +736,22 @@ declare -a TEMP_FILES=()
 track_temp_dir()  { TEMP_DIRS+=("$1"); }
 track_temp_file() { TEMP_FILES+=("$1"); }
 
+untrack_temp_file() {
+  local f="$1" i
+  for i in "${!TEMP_FILES[@]}"; do
+    [[ "${TEMP_FILES[$i]}" == "$f" ]] && unset 'TEMP_FILES[$i]'
+  done
+}
+
+cleanup_temp_file_now() {
+  local f="$1"
+  if [[ -n "$f" && -f "$f" ]]; then
+    rm -f -- "$f"
+    log INFO "🗑️ Removed temp file: $f"
+  fi
+  untrack_temp_file "$f"
+}
+
 cleanup_temp_dir_now() {
   local d="$1"
   [[ -n "$d" && -d "$d" ]] || return 0
@@ -790,13 +806,15 @@ verify_chds() {
 
     if [[ "$DRY_RUN" == true ]]; then
         for chd in "${chds[@]}"; do
-            log INFO "🧪 (dry-run) Would verify: $outdir/$chd"
+            [[ -n "$outdir" ]] && chd="$outdir/$chd"
+            log INFO "🧪 (dry-run) Would verify: $chd"
         done
         return 0
     fi
 
     for chd in "${chds[@]}"; do
-        local chd_path="$outdir/$chd"
+        local chd_path="$chd"
+        [[ -n "$outdir" ]] && chd_path="$outdir/$chd"
         if [[ ! -f "$chd_path" ]]; then
             all_verified=false
             break
@@ -1059,6 +1077,9 @@ convert_disc_file() {
     local file="$1"
     local outdir="$2"
     local base_override="${3:-}"
+    local result_var="${4:-}"
+
+    [[ -n "$result_var" ]] && printf -v "$result_var" '%s' ""
 
     # If it's a CUE, validate referenced files first
     if [[ "${file,,}" == *.cue ]]; then
@@ -1076,7 +1097,6 @@ convert_disc_file() {
     fi
 
     local chd_path="$outdir/$base.chd"
-    local tmp_chd="$outdir/$base.chd.tmp"
 
     # If a CHD already exists, verify it and skip if good
     if [[ -f "$chd_path" ]]; then
@@ -1144,7 +1164,6 @@ convert_disc_file() {
     esac
 
     log INFO "$icon Detected $disc_type image → using chdman $subcmd"
-    log INFO "🔧 Converting: $file -> $tmp_chd"
 
     # Calculate safe threads: ~one thread per 2GB RAM (for CDs) or 4GB RAM (for DVDs)
     local total_ram_mb=$(( $(awk '/MemTotal|SwapTotal/{sum+=$2} END{print sum}' /proc/meminfo) / 1024 ))
@@ -1170,18 +1189,36 @@ convert_disc_file() {
     (( threads > cpu_cores )) && threads=$cpu_cores
 
     if [[ "$DRY_RUN" == true ]]; then
-        log INFO "🧪 (dry-run) Would run: ${CHDMAN_BIN:-chdman} $subcmd -np $threads -i \"$file\" -o \"$tmp_chd\""
+        log INFO "🧪 (dry-run) Would run: ${CHDMAN_BIN:-chdman} $subcmd -np $threads -i \"$file\" -o a unique temporary CHD beside \"$chd_path\""
         return 0
     fi
 
+    # Reserve a unique location in the destination filesystem. Keeping the
+    # reservation directory until finalisation prevents concurrent runs from
+    # ever allocating or writing the same temporary path.
+    local tmp_dir tmp_chd
+    tmp_dir="$(mktemp -d -p "$outdir" ".${base}.chd.tmp.${RUN_ID}.XXXXXX")" || {
+        log ERROR "❌ Could not allocate temporary CHD path for: $chd_path"
+        return 1
+    }
+    track_temp_dir "$tmp_dir"
+    tmp_chd="$tmp_dir/$base.chd"
+    track_temp_file "$tmp_chd"
+    [[ -n "$result_var" ]] && printf -v "$result_var" '%s' "$tmp_chd"
+    log INFO "🔧 Converting: $file -> $tmp_chd"
+
     if [[ -t 2 && "${PROGRESS_STYLE:-$PROGRESS_STYLE_DEFAULT}" != "none" ]]; then
-    if ! PHASE_DEFAULT="Converting" stdbuf -oL -eL "${CHDMAN_BIN:-chdman}" "$subcmd" -np "$threads" -hs "$hunk_size" -i "$file" -o "$tmp_chd" 2>&1 | _chdman_progress_filter; then
+        if ! PHASE_DEFAULT="Converting" stdbuf -oL -eL "${CHDMAN_BIN:-chdman}" "$subcmd" -np "$threads" -hs "$hunk_size" -i "$file" -o "$tmp_chd" 2>&1 | _chdman_progress_filter; then
             log ERROR "❌ chdman $subcmd failed for: $file"
+            cleanup_temp_file_now "$tmp_chd"
+            cleanup_temp_dir_now "$tmp_dir"
             return 1
         fi
     else
         if ! "${CHDMAN_BIN:-chdman}" "$subcmd" -np "$threads" -hs "$hunk_size" -i "$file" -o "$tmp_chd"; then
             log ERROR "❌ chdman $subcmd failed for: $file"
+            cleanup_temp_file_now "$tmp_chd"
+            cleanup_temp_dir_now "$tmp_dir"
             return 1
         fi
     fi
@@ -1350,6 +1387,7 @@ process_input() {
 
     local archive_chd_size=0
     local tmp_chds=()
+    local final_chds=()
 
     if [[ "$DRY_RUN" == true ]]; then
         for disc in "${disc_files[@]}"; do
@@ -1377,8 +1415,12 @@ process_input() {
             chd_name="$(archive_entry_to_chd_name "$entry")"   # e.g. "CD1 - Game.chd"
             chd_base="${chd_name%.chd}"                        # e.g. "CD1 - Game"
 
-            if convert_disc_file "$extracted" "$outdir" "$chd_base"; then
-                tmp_chds+=("$outdir/$chd_name.tmp")
+            local converted_tmp=""
+            if convert_disc_file "$extracted" "$outdir" "$chd_base" converted_tmp; then
+                if [[ -n "$converted_tmp" ]]; then
+                    tmp_chds+=("$converted_tmp")
+                    final_chds+=("$outdir/$chd_name")
+                fi
             else
                 input_failed=true
             fi
@@ -1391,8 +1433,12 @@ process_input() {
     else
         # Non-archive inputs keep the old behaviour
         for disc in "${disc_files[@]}"; do
-            if convert_disc_file "$disc" "$outdir"; then
-                tmp_chds+=("$outdir/$(basename "${disc%.*}").chd.tmp")
+            local converted_tmp=""
+            if convert_disc_file "$disc" "$outdir" "" converted_tmp; then
+                if [[ -n "$converted_tmp" ]]; then
+                    tmp_chds+=("$converted_tmp")
+                    final_chds+=("$outdir/$(basename "${disc%.*}").chd")
+                fi
             else
                 input_failed=true
             fi
@@ -1401,10 +1447,14 @@ process_input() {
 
     # Verify .tmp CHDs and finalize
     if [[ "$DRY_RUN" != true && ${#tmp_chds[@]} -gt 0 ]]; then
-        if verify_chds "$outdir" "${tmp_chds[@]##*/}"; then
-            for tmp_chd in "${tmp_chds[@]}"; do
-                local final_chd="${tmp_chd%.tmp}"
+        if verify_chds "" "${tmp_chds[@]}"; then
+            local i
+            for i in "${!tmp_chds[@]}"; do
+                local tmp_chd="${tmp_chds[$i]}"
+                local final_chd="${final_chds[$i]}"
                 mv -f -- "$tmp_chd" "$final_chd"
+                untrack_temp_file "$tmp_chd"
+                cleanup_temp_dir_now "$(dirname "$tmp_chd")"
                 log INFO "🔄 Replaced old CHD with new verified CHD: $final_chd"
                 chds_created=$((chds_created + 1))
             done
@@ -1423,10 +1473,8 @@ process_input() {
             fi
         else
             for tmp_chd in "${tmp_chds[@]}"; do
-                if [[ -f "$tmp_chd" ]]; then
-                    rm -f "$tmp_chd"
-                    log INFO "🗑️ Removed failed tmp CHD: $tmp_chd"
-                fi
+                cleanup_temp_file_now "$tmp_chd"
+                cleanup_temp_dir_now "$(dirname "$tmp_chd")"
             done
             input_failed=true
             log WARN "⚠️ CHD verification failed after conversion for $input_file, keeping original"

--- a/tests/bin/chdman
+++ b/tests/bin/chdman
@@ -20,7 +20,14 @@ case "$1" in
         *) shift ;;
       esac
     done
+    if [[ -n "${CHDMAN_READY_FILE:-}" ]]; then
+      printf '%s\n' "$output" > "$CHDMAN_READY_FILE"
+    fi
+    if [[ -n "${CHDMAN_PAUSE_SECONDS:-}" ]]; then
+      sleep "$CHDMAN_PAUSE_SECONDS"
+    fi
     if [[ -n "${CHDMAN_FAIL_INPUT:-}" && "$input" == *"$CHDMAN_FAIL_INPUT"* ]]; then
+      : > "$output"
       echo "stub chdman: requested failure for $input" >&2
       exit 2
     fi

--- a/tests/test_temporary_chd_cleanup.sh
+++ b/tests/test_temporary_chd_cleanup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${SCRIPT:-$REPO_ROOT/chdtool.sh}"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+
+export PATH="$REPO_ROOT/tests/bin:$PATH"
+export PROGRESS_STYLE=none
+export LOG_DEST=console
+export LOG_LEVEL_THRESHOLD=ERROR
+
+assert_no_temporary_chds() {
+  if find "$FIX" -name '*.chd.tmp.*' -print -quit | grep -q .; then
+    echo "FAIL: temporary CHD allocation remained in $FIX" >&2
+    find "$FIX" -name '*.chd.tmp.*' -print >&2
+    exit 1
+  fi
+}
+
+# A failed converter writes a partial output; chdtool must remove it immediately.
+: > "$FIX/Failure Game.iso"
+CHDMAN_FAIL_INPUT="Failure Game.iso" bash "$SCRIPT" "$FIX" || true
+assert_no_temporary_chds
+[[ ! -e "$FIX/Failure Game.chd" ]] || {
+  echo "FAIL: failed conversion produced a final CHD" >&2
+  exit 1
+}
+rm -f "$FIX/Failure Game.iso"
+
+# A signal while chdman is active must run the same tracked-file cleanup.
+: > "$FIX/Interrupted Game.iso"
+READY_FILE="$FIX/chdman.ready"
+CHDMAN_READY_FILE="$READY_FILE" CHDMAN_PAUSE_SECONDS=2 \
+  bash "$SCRIPT" "$FIX" &
+script_pid=$!
+
+for _ in {1..100}; do
+  [[ -s "$READY_FILE" ]] && break
+  sleep 0.05
+done
+[[ -s "$READY_FILE" ]] || {
+  echo "FAIL: timed out waiting for chdman to start" >&2
+  kill "$script_pid" 2>/dev/null || true
+  wait "$script_pid" 2>/dev/null || true
+  exit 1
+}
+
+tmp_path="$(tr -d '\r\n' < "$READY_FILE")"
+[[ "$tmp_path" == "$FIX"/* && "$tmp_path" == *'.chd.tmp.'*/*'.chd' ]] || {
+  echo "FAIL: chdman did not receive a unique destination-local temporary path: $tmp_path" >&2
+  exit 1
+}
+
+kill -TERM "$script_pid"
+wait "$script_pid" 2>/dev/null || true
+sleep 2.2
+assert_no_temporary_chds
+[[ ! -e "$FIX/Interrupted Game.chd" ]] || {
+  echo "FAIL: interrupted conversion produced a final CHD" >&2
+  exit 1
+}
+
+echo "PASS: failed and interrupted conversions clean unique temporary CHDs"


### PR DESCRIPTION
## Summary

- allocate each temporary CHD in a unique, destination-local reservation directory
- track temporary outputs immediately and clean them after conversion failures or interruption
- atomically finalise verified CHDs and untrack successful outputs
- add regression coverage for failed and interrupted conversion cleanup

## Why

Predictable .chd.tmp paths could collide across concurrent runs and partial outputs could remain after a failed or interrupted chdman process. Keeping each allocation reserved on the destination filesystem prevents temporary-path sharing while preserving atomic finalisation.

## Validation

- make test
- Bash syntax checks
- ShellCheck
- git diff --check

Closes #29