### PR TITLE
fix: support reliable partial resume with explicit output states

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SHELL := /usr/bin/env bash
 # Path to your script; override with: make test SCRIPT=./path/to/script.sh
 SCRIPT ?= ./chdtool.sh
 
-.PHONY: test test-m3u test-m3u-single test-transactional-source-deletion test-temporary-chd-cleanup test-logging test-setup clean changelog changelog-tag
+.PHONY: test test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-logging test-setup clean changelog changelog-tag
 
-test: test-setup test-m3u test-m3u-single test-transactional-source-deletion test-temporary-chd-cleanup test-logging
+test: test-setup test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-logging
 
 test-setup:
 	chmod +x tests/bin/chdman
@@ -13,6 +13,7 @@ test-setup:
 	-chmod +x tests/bin/7z
 	chmod +x tests/test_m3u.sh tests/test_m3u_single.sh tests/test_transactional_source_deletion.sh
 	chmod +x tests/test_temporary_chd_cleanup.sh
+	chmod +x tests/test_partial_resume.sh
 	@if [ -f tests/test_logging.sh ]; then chmod +x tests/test_logging.sh; fi
 
 test-m3u:
@@ -20,6 +21,9 @@ test-m3u:
 
 test-m3u-single:
 	SCRIPT=$(SCRIPT) bash tests/test_m3u_single.sh
+
+test-partial-resume:
+	SCRIPT=$(SCRIPT) bash tests/test_partial_resume.sh
 
 test-transactional-source-deletion:
 	SCRIPT=$(SCRIPT) bash tests/test_transactional_source_deletion.sh

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -1242,6 +1242,17 @@ process_input() {
     local ext_regex
     ext_regex="$(build_ext_regex "${disc_exts[@]}")"
     local temp_dir=""
+    declare -A output_states=()
+    declare -A output_temps=()
+
+    _all_outputs_complete() {
+        local expected state
+        for expected in "${expected_chds[@]}"; do
+            state="${output_states[$expected]:-missing}"
+            [[ "$state" == "already_verified" || "$state" == "finalised" ]] || return 1
+        done
+        return 0
+    }
 
     _return_failed_input() {
         failures=$((failures + 1))
@@ -1303,9 +1314,19 @@ process_input() {
         fi
     fi
 
+    # Establish one authoritative state for every expected output.
+    local expected_chd
+    for expected_chd in "${expected_chds[@]}"; do
+        if [[ -f "$outdir/$expected_chd" ]] && verify_chds "$outdir" "$expected_chd"; then
+            output_states["$expected_chd"]="already_verified"
+        else
+            output_states["$expected_chd"]="missing"
+        fi
+    done
+
     # If all expected CHDs already exist and verify, generate the complete-set
     # playlist before treating source removal as the final action.
-    if [[ "$input_failed" != true ]] && verify_chds "$outdir" "${expected_chds[@]}"; then
+    if [[ "$input_failed" != true ]] && _all_outputs_complete; then
         log INFO "✅ All expected CHDs verified for $input_file"
         if [[ ${#expected_chds[@]} -gt 0 ]]; then
             local chd_base
@@ -1415,13 +1436,18 @@ process_input() {
             chd_name="$(archive_entry_to_chd_name "$entry")"   # e.g. "CD1 - Game.chd"
             chd_base="${chd_name%.chd}"                        # e.g. "CD1 - Game"
 
+            [[ "${output_states[$chd_name]:-missing}" == "already_verified" ]] && continue
+
             local converted_tmp=""
             if convert_disc_file "$extracted" "$outdir" "$chd_base" converted_tmp; then
                 if [[ -n "$converted_tmp" ]]; then
                     tmp_chds+=("$converted_tmp")
                     final_chds+=("$outdir/$chd_name")
+                    output_temps["$chd_name"]="$converted_tmp"
+                    output_states["$chd_name"]="converted_pending_verification"
                 fi
             else
+                output_states["$chd_name"]="failed"
                 input_failed=true
             fi
         done
@@ -1433,66 +1459,67 @@ process_input() {
     else
         # Non-archive inputs keep the old behaviour
         for disc in "${disc_files[@]}"; do
+            local chd_name
+            chd_name="$(get_chd_basename "$disc").chd"
+            [[ "${output_states[$chd_name]:-missing}" == "already_verified" ]] && continue
+
             local converted_tmp=""
             if convert_disc_file "$disc" "$outdir" "" converted_tmp; then
                 if [[ -n "$converted_tmp" ]]; then
                     tmp_chds+=("$converted_tmp")
-                    final_chds+=("$outdir/$(basename "${disc%.*}").chd")
+                    final_chds+=("$outdir/$chd_name")
+                    output_temps["$chd_name"]="$converted_tmp"
+                    output_states["$chd_name"]="converted_pending_verification"
                 fi
             else
+                output_states["$chd_name"]="failed"
                 input_failed=true
             fi
         done
     fi
 
-    # Verify .tmp CHDs and finalize
+    # Verify and finalise pending outputs independently. Existing verified
+    # outputs are never added to this temporary-output verification pass.
     if [[ "$DRY_RUN" != true && ${#tmp_chds[@]} -gt 0 ]]; then
-        if verify_chds "" "${tmp_chds[@]}"; then
-            local i
-            for i in "${!tmp_chds[@]}"; do
-                local tmp_chd="${tmp_chds[$i]}"
-                local final_chd="${final_chds[$i]}"
+        local chd_name tmp_chd final_chd
+        for chd_name in "${expected_chds[@]}"; do
+            [[ "${output_states[$chd_name]:-missing}" == "converted_pending_verification" ]] || continue
+            tmp_chd="${output_temps[$chd_name]}"
+            final_chd="$outdir/$chd_name"
+            if verify_chds "" "$tmp_chd"; then
                 mv -f -- "$tmp_chd" "$final_chd"
                 untrack_temp_file "$tmp_chd"
                 cleanup_temp_dir_now "$(dirname "$tmp_chd")"
                 log INFO "🔄 Replaced old CHD with new verified CHD: $final_chd"
                 chds_created=$((chds_created + 1))
-            done
-
-            for chd in "${expected_chds[@]}"; do
-                if [[ -f "$outdir/$chd" ]]; then
-                    archive_chd_size=$((archive_chd_size + $(get_file_size "$outdir/$chd")))
-                fi
-            done
-            if [[ $archive_size_bytes -gt 0 ]]; then
-                local saving=$((archive_size_bytes - archive_chd_size))
-                local saving_percent=$((100 * saving / archive_size_bytes))
-                log INFO "📉 Space saving for $(basename "$input_file"): $(human_readable "$archive_size_bytes") → $(human_readable "$archive_chd_size"), saved $(human_readable "$saving") (${saving_percent}%)"
-                total_original_size=$((total_original_size + archive_size_bytes))
-                total_chd_size=$((total_chd_size + archive_chd_size))
-            fi
-        else
-            for tmp_chd in "${tmp_chds[@]}"; do
+                output_states["$chd_name"]="finalised"
+            else
                 cleanup_temp_file_now "$tmp_chd"
                 cleanup_temp_dir_now "$(dirname "$tmp_chd")"
-            done
-            input_failed=true
-            log WARN "⚠️ CHD verification failed after conversion for $input_file, keeping original"
-        fi
+                output_states["$chd_name"]="failed"
+                input_failed=true
+                log WARN "⚠️ CHD verification failed after conversion for $chd_name"
+            fi
+        done
     fi
 
-    if [[ "$input_failed" == true ]]; then
+    if [[ "$input_failed" == true ]] || ! _all_outputs_complete; then
         log WARN "⚠️ Not all expected members converted successfully for $input_file, keeping original"
         _return_failed_input
         return 1
     fi
 
-    # Source deletion is the final action. First require the complete expected
-    # final CHD set to exist and pass verification, then generate its playlist.
-    if ! verify_chds "$outdir" "${expected_chds[@]}"; then
-        log WARN "⚠️ Complete final CHD set failed verification for $input_file, keeping original"
-        _return_failed_input
-        return 1
+    # Source deletion, accounting, and M3U generation all consume the same
+    # complete manifest rather than independently inferring success.
+    for chd_name in "${expected_chds[@]}"; do
+        archive_chd_size=$((archive_chd_size + $(get_file_size "$outdir/$chd_name")))
+    done
+    if [[ $archive_size_bytes -gt 0 ]]; then
+        local saving=$((archive_size_bytes - archive_chd_size))
+        local saving_percent=$((100 * saving / archive_size_bytes))
+        log INFO "📉 Space saving for $(basename "$input_file"): $(human_readable "$archive_size_bytes") → $(human_readable "$archive_chd_size"), saved $(human_readable "$saving") (${saving_percent}%)"
+        total_original_size=$((total_original_size + archive_size_bytes))
+        total_chd_size=$((total_chd_size + archive_chd_size))
     fi
 
     if [[ ${#expected_chds[@]} -gt 0 ]]; then

--- a/tests/bin/chdman
+++ b/tests/bin/chdman
@@ -6,6 +6,17 @@ case "$1" in
     echo "chdman 0.000 (stub) - createdvd createcd verify"; exit 0
     ;;
   verify)
+    verify_input=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -i) verify_input="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [[ -f "$verify_input" ]] && grep -q '^INVALID$' "$verify_input"; then
+      echo "invalid CHD" >&2
+      exit 2
+    fi
     # your script greps for "complete" and optionally "(ratio=..%)"
     echo "Verifying, 100% complete (ratio=50%)" >&2
     exit 0
@@ -31,7 +42,8 @@ case "$1" in
       echo "stub chdman: requested failure for $input" >&2
       exit 2
     fi
-    : > "$output"
+    [[ -n "${CHDMAN_CREATE_LOG:-}" ]] && printf '%s\n' "$input" >> "$CHDMAN_CREATE_LOG"
+    printf 'converted:%s\n' "$input" > "$output"
     echo "Compressing, 100% complete (ratio=50%)" >&2
     exit 0
     ;;

--- a/tests/test_partial_resume.sh
+++ b/tests/test_partial_resume.sh
@@ -21,7 +21,10 @@ make_archive "$archive" "Resume Game (Disc 1).iso" "Resume Game (Disc 2).iso"
 create_log="$FIX/create.log"
 CHDMAN_CREATE_LOG="$create_log" bash "$SCRIPT" "$FIX"
 [[ "$(cat "$FIX/Resume Game (Disc 1).chd")" == "existing-valid" ]] || { echo "FAIL: valid CHD replaced" >&2; exit 1; }
-[[ "$(wc -l < "$create_log")" -eq 1 ]] && grep -q 'Disc 2' "$create_log" || { echo "FAIL: expected only Disc 2 conversion" >&2; exit 1; }
+if [[ "$(wc -l < "$create_log")" -ne 1 ]] || ! grep -q 'Disc 2' "$create_log"; then
+  echo "FAIL: expected only Disc 2 conversion" >&2
+  exit 1
+fi
 [[ -f "$FIX/Resume Game (Disc 2).chd" && -f "$FIX/Resume Game.m3u" && ! -e "$archive" ]] || { echo "FAIL: resumed set incomplete" >&2; exit 1; }
 
 printf 'INVALID\n' > "$FIX/Replace Game.chd"

--- a/tests/test_partial_resume.sh
+++ b/tests/test_partial_resume.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${SCRIPT:-$REPO_ROOT/chdtool.sh}"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+export PATH="$REPO_ROOT/tests/bin:$PATH"
+export PROGRESS_STYLE=none LOG_DEST=console LOG_LEVEL_THRESHOLD=ERROR
+
+make_archive() {
+  local archive="$1"; shift
+  (cd "$FIX" && zip -q "$(basename "$archive")" "$@" && rm -f -- "$@")
+}
+
+printf 'existing-valid\n' > "$FIX/Resume Game (Disc 1).chd"
+: > "$FIX/Resume Game (Disc 1).iso"
+: > "$FIX/Resume Game (Disc 2).iso"
+archive="$FIX/resume-game.zip"
+make_archive "$archive" "Resume Game (Disc 1).iso" "Resume Game (Disc 2).iso"
+create_log="$FIX/create.log"
+CHDMAN_CREATE_LOG="$create_log" bash "$SCRIPT" "$FIX"
+[[ "$(cat "$FIX/Resume Game (Disc 1).chd")" == "existing-valid" ]] || { echo "FAIL: valid CHD replaced" >&2; exit 1; }
+[[ "$(wc -l < "$create_log")" -eq 1 ]] && grep -q 'Disc 2' "$create_log" || { echo "FAIL: expected only Disc 2 conversion" >&2; exit 1; }
+[[ -f "$FIX/Resume Game (Disc 2).chd" && -f "$FIX/Resume Game.m3u" && ! -e "$archive" ]] || { echo "FAIL: resumed set incomplete" >&2; exit 1; }
+
+printf 'INVALID\n' > "$FIX/Replace Game.chd"
+: > "$FIX/Replace Game.iso"
+archive="$FIX/replace-game.zip"
+make_archive "$archive" "Replace Game.iso"
+: > "$create_log"
+CHDMAN_CREATE_LOG="$create_log" bash "$SCRIPT" "$FIX"
+[[ "$(wc -l < "$create_log")" -eq 1 ]] || { echo "FAIL: invalid CHD not converted once" >&2; exit 1; }
+grep -q '^converted:' "$FIX/Replace Game.chd" || { echo "FAIL: invalid CHD not replaced" >&2; exit 1; }
+[[ ! -e "$archive" ]] || { echo "FAIL: source retained after replacement" >&2; exit 1; }
+
+echo "PASS: partial resume uses explicit output states"


### PR DESCRIPTION
## Summary

- track an explicit state for every expected CHD
- skip existing verified outputs during resumed conversion and temporary verification
- verify and finalise newly converted outputs independently
- drive final success, source deletion, accounting, and M3U generation from the same output manifest
- safely replace invalid existing CHDs through verified temporary outputs

## Root cause

`convert_disc_file` returned success both when it created a temporary CHD and when it merely verified an existing final CHD. The caller could therefore treat a non-existent temporary path as pending verification during a partially completed multi-disc resume.

## Validation

- `make test`
- `shellcheck chdtool.sh tests/*.sh tests/bin/*`
- regression: one existing valid CHD plus one newly converted CHD
- regression: an existing invalid CHD is safely replaced

Closes #28