### PR TITLE
fix: return meaningful status when inputs fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SHELL := /usr/bin/env bash
 # Path to your script; override with: make test SCRIPT=./path/to/script.sh
 SCRIPT ?= ./chdtool.sh
 
-.PHONY: test test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-logging test-setup clean changelog changelog-tag
+.PHONY: test test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-exit-status test-logging test-setup clean changelog changelog-tag
 
-test: test-setup test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-logging
+test: test-setup test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-exit-status test-logging
 
 test-setup:
 	chmod +x tests/bin/chdman
@@ -14,6 +14,7 @@ test-setup:
 	chmod +x tests/test_m3u.sh tests/test_m3u_single.sh tests/test_transactional_source_deletion.sh
 	chmod +x tests/test_temporary_chd_cleanup.sh
 	chmod +x tests/test_partial_resume.sh
+	chmod +x tests/test_exit_status.sh
 	@if [ -f tests/test_logging.sh ]; then chmod +x tests/test_logging.sh; fi
 
 test-m3u:
@@ -30,6 +31,9 @@ test-transactional-source-deletion:
 
 test-temporary-chd-cleanup:
 	SCRIPT=$(SCRIPT) bash tests/test_temporary_chd_cleanup.sh
+
+test-exit-status:
+	SCRIPT=$(SCRIPT) bash tests/test_exit_status.sh
 
 test-logging:
 	@if [ -f tests/test_logging.sh ]; then \

--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ At the end of a run:
 - Failures
 - Elapsed time
 
+### Exit statuses
+
+- `0` — clean success, including intentional skips and already-complete inputs
+- `1` — usage, configuration, or startup failure
+- `2` — one or more discovered inputs failed; independent inputs were still processed
+- `130` — interrupted by SIGINT or SIGTERM
+
 ---
 
 ## ⚙️ Requirements

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -1235,6 +1235,8 @@ process_input() {
     local outdir
     outdir="$(dirname "$input_file")"
     local archive_entries=()
+    local archive_listing=""
+    local archive_listing_exit=0
     local disc_files=()
     local expected_chds=()
     local archive_size_bytes
@@ -1277,9 +1279,26 @@ process_input() {
     if is_in_list "$ext" "${archive_exts[@]}"; then
         archives_processed=$((archives_processed + 1))
         case "$ext" in
-            zip) mapfile -t archive_entries < <(unzip -Z1 -- "$input_file" | grep -Ei "$ext_regex") ;;
-            rar) mapfile -t archive_entries < <(unrar lb -- "$input_file" | grep -Ei "$ext_regex") ;;
-            7z|7zip) mapfile -t archive_entries < <(7z l -slt -- "$input_file" 2>/dev/null | awk -v IGNORECASE=1 -v re="$ext_regex" '/^Path = /{p=substr($0,8); if(p~re) print p}') ;;
+            zip)
+                if archive_listing="$(unzip -Z1 -- "$input_file")"; then :; else archive_listing_exit=$?; fi
+                ;;
+            rar)
+                if archive_listing="$(unrar lb -- "$input_file")"; then :; else archive_listing_exit=$?; fi
+                ;;
+            7z|7zip)
+                if archive_listing="$(7z l -slt -- "$input_file")"; then :; else archive_listing_exit=$?; fi
+                ;;
+        esac
+
+        if [[ $archive_listing_exit -ne 0 ]]; then
+            log ERROR "❌ Archive listing failed for $input_file (Exit code: $archive_listing_exit). Skipping."
+            _return_failed_input
+            return 1
+        fi
+
+        case "$ext" in
+            zip|rar) mapfile -t archive_entries < <(grep -Ei "$ext_regex" <<< "$archive_listing" || true) ;;
+            7z|7zip) mapfile -t archive_entries < <(awk -v IGNORECASE=1 -v re="$ext_regex" '/^Path = /{p=substr($0,8); if(p~re) print p}' <<< "$archive_listing") ;;
         esac
 
         if [[ ${#archive_entries[@]} -gt 0 ]]; then
@@ -1570,4 +1589,10 @@ log INFO "📦 Archives processed: $archives_processed"
 log INFO "💿 CHDs created:       $chds_created"
 log INFO "❌ Failures:           $failures"
 log INFO "⏱️ Elapsed time: $(format_duration $(( $(date +%s) - script_start_time )))"
-log INFO "✅ Done!"
+if [[ $failures -gt 0 ]]; then
+    log ERROR "⚠️ Completed with failures ($failures input(s) failed)."
+    exit 2
+fi
+
+log INFO "✅ Completed successfully."
+exit 0

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -447,6 +447,8 @@ _now_ms() {
 # Use with: PHASE_DEFAULT="Converting" chdman createcd … | _chdman_progress_filter
 #        or: PHASE_DEFAULT="Verifying"  chdman verify … | _chdman_progress_filter
 _chdman_progress_filter() {
+    # Invoked indirectly by the traps below.
+    # shellcheck disable=SC2317
     _restore_wrap() { _term_print "\033[?7h"; }
     trap '_restore_wrap; return 130' INT TERM
     trap _restore_wrap EXIT
@@ -764,12 +766,16 @@ cleanup_temp_dir_now() {
   done
 }
 
+# Invoked indirectly through _on_interrupt's signal trap.
+# shellcheck disable=SC2317
 _restore_wrap_global() {
   # Make sure terminal autowrap is re-enabled and the progress line cleared
   # (safe to emit even if no progress was showing)
   _term_print "\r\033[2K\033[?7h\n"
 }
 
+# Invoked indirectly by the EXIT trap and the signal handler.
+# shellcheck disable=SC2317
 cleanup_all() {
     # Temp dirs
     for d in "${TEMP_DIRS[@]:-}"; do
@@ -786,6 +792,8 @@ cleanup_all() {
     done
 }
 
+# Invoked indirectly by the INT and TERM traps.
+# shellcheck disable=SC2317
 _on_interrupt() {
   # One place to handle Ctrl-C/TERM: restore terminal, clean, then exit(130)
   _restore_wrap_global

--- a/tests/test_exit_status.sh
+++ b/tests/test_exit_status.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${SCRIPT:-$REPO_ROOT/chdtool.sh}"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+
+export PATH="$REPO_ROOT/tests/bin:$PATH"
+export PROGRESS_STYLE=none
+export LOG_DEST=console
+export LOG_LEVEL_THRESHOLD=INFO
+
+run_and_capture() {
+  local output_file="$1"; shift
+  set +e
+  "$@" >"$output_file" 2>&1
+  RUN_STATUS=$?
+  set -e
+}
+
+mkdir "$FIX/success"
+: > "$FIX/success/Success Game.iso"
+run_and_capture "$FIX/success.log" bash "$SCRIPT" "$FIX/success"
+[[ $RUN_STATUS -eq 0 ]] || { echo "FAIL: success returned $RUN_STATUS, expected 0" >&2; exit 1; }
+grep -q 'Completed successfully' "$FIX/success.log" || { echo "FAIL: clean completion log missing" >&2; exit 1; }
+
+run_and_capture "$FIX/startup.log" bash "$SCRIPT" "$FIX/does-not-exist"
+[[ $RUN_STATUS -eq 1 ]] || { echo "FAIL: startup failure returned $RUN_STATUS, expected 1" >&2; exit 1; }
+
+mkdir "$FIX/listing" "$FIX/listing-bin"
+: > "$FIX/listing/Broken.zip"
+cat > "$FIX/listing-bin/unzip" <<'STUB'
+#!/usr/bin/env bash
+echo "stub unzip: unreadable archive" >&2
+exit 9
+STUB
+chmod +x "$FIX/listing-bin/unzip"
+run_and_capture "$FIX/listing.log" env PATH="$FIX/listing-bin:$PATH" bash "$SCRIPT" "$FIX/listing"
+[[ $RUN_STATUS -eq 2 ]] || { echo "FAIL: archive listing failure returned $RUN_STATUS, expected 2" >&2; exit 1; }
+grep -q 'Archive listing failed' "$FIX/listing.log" || { echo "FAIL: listing failure was not reported explicitly" >&2; exit 1; }
+if grep -q 'no disc files found' "$FIX/listing.log"; then
+  echo "FAIL: listing failure was reported as an empty archive" >&2
+  exit 1
+fi
+grep -q 'Completed with failures' "$FIX/listing.log" || { echo "FAIL: failed completion log missing" >&2; exit 1; }
+
+echo "PASS: success, startup, and archive-listing exit statuses"

--- a/tests/test_temporary_chd_cleanup.sh
+++ b/tests/test_temporary_chd_cleanup.sh
@@ -54,7 +54,14 @@ tmp_path="$(tr -d '\r\n' < "$READY_FILE")"
 }
 
 kill -TERM "$script_pid"
-wait "$script_pid" 2>/dev/null || true
+set +e
+wait "$script_pid" 2>/dev/null
+interrupt_status=$?
+set -e
+[[ $interrupt_status -eq 130 ]] || {
+  echo "FAIL: interruption returned $interrupt_status, expected 130" >&2
+  exit 1
+}
 sleep 2.2
 assert_no_temporary_chds
 [[ ! -e "$FIX/Interrupted Game.chd" ]] || {

--- a/tests/test_transactional_source_deletion.sh
+++ b/tests/test_transactional_source_deletion.sh
@@ -23,8 +23,11 @@ ARCHIVE="$FIX/transactional-game.zip"
   rm -f "Transactional Game (Disc 1).iso" "Transactional Game (Disc 2).iso"
 )
 
-# Issue #30 owns the overall process exit status; this test asserts filesystem effects only.
-bash "$SCRIPT" "$FIX" || true
+set +e
+bash "$SCRIPT" "$FIX"
+status=$?
+set -e
+[[ $status -eq 2 ]] || { echo "FAIL: partial conversion returned $status, expected 2" >&2; exit 1; }
 
 if [[ ! -f "$ARCHIVE" ]]; then
   echo "FAIL: source archive was deleted after a partial conversion" >&2


### PR DESCRIPTION
## Summary

- return exit status 2 when one or more discovered inputs fail while continuing independent inputs
- preserve status 0 for clean, skipped, and already-complete runs; status 1 for startup/configuration errors; and status 130 for interruption
- detect archive-listing command failures explicitly and distinguish clean completion from completion with failures
- document the stable exit-status contract and add regression coverage for success, partial failure, archive-listing failure, startup failure, and interruption

## Root cause

The processing loop counted failures but always reached a successful process exit. Archive listings were read through process substitutions, which hid the listing command's status and made unreadable archives look empty.

## Impact

Cron jobs, containers, CI, and other automation can now reliably detect partial conversion failures without preventing unrelated inputs from being processed.

## Validation

- `make test`
- `shellcheck chdtool.sh tests/*.sh tests/bin/*`

Closes #30
Related to #33