### PR TITLE
Harden descriptor validation and improve resource handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SHELL := /usr/bin/env bash
 # Path to your script; override with: make test SCRIPT=./path/to/script.sh
 SCRIPT ?= ./chdtool.sh
 
-.PHONY: test test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-exit-status test-logging test-setup clean changelog changelog-tag
+.PHONY: test test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-exit-status test-logging test-security-validation test-resource-handling test-setup clean changelog changelog-tag
 
-test: test-setup test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-exit-status test-logging
+test: test-setup test-m3u test-m3u-single test-partial-resume test-transactional-source-deletion test-temporary-chd-cleanup test-exit-status test-logging test-security-validation test-resource-handling
 
 test-setup:
 	chmod +x tests/bin/chdman
@@ -15,6 +15,8 @@ test-setup:
 	chmod +x tests/test_temporary_chd_cleanup.sh
 	chmod +x tests/test_partial_resume.sh
 	chmod +x tests/test_exit_status.sh
+	chmod +x tests/test_security_validation.sh
+	chmod +x tests/test_resource_handling.sh
 	@if [ -f tests/test_logging.sh ]; then chmod +x tests/test_logging.sh; fi
 
 test-m3u:
@@ -41,6 +43,12 @@ test-logging:
 	else \
 	  echo "Skipping logging test (tests/test_logging.sh not present)"; \
 	fi
+
+test-security-validation:
+	SCRIPT=$(SCRIPT) bash tests/test_security_validation.sh
+
+test-resource-handling:
+	SCRIPT=$(SCRIPT) bash tests/test_resource_handling.sh
 
 clean:
 	@echo "Nothing to clean; tests use mktemp dirs."

--- a/README.md
+++ b/README.md
@@ -197,12 +197,30 @@ Use `--dry-run` to preview actions:
 - No files are created, moved, or deleted
 - All intended operations are logged
 
+### Resource selection
+
+By default, CHD Tool lets `chdman` choose its format-appropriate hunk size. It
+selects compression threads conservatively from Linux `MemAvailable` (never
+swap), using roughly 2 GiB per CD thread or 4 GiB per DVD thread, and caps the
+result at the available CPU count with a minimum of one.
+
+- `CHDMAN_THREADS=N` requests a positive thread count; values above the CPU count
+  are capped
+- `CHDMAN_HUNK_SIZE=N` is an advanced opt-in that passes `-hs N` to `chdman`
+
 ---
 
 ## ⚠️ Notes
 
 - DVD support requires a version of `chdman` with `createdvd`
 - CUE files referencing missing files will fail validation
+- CUE/GDI/CCD paths must be relative and remain below the descriptor directory;
+  nested paths and unambiguous case-insensitive matches are supported
+- A successfully converted direct descriptor is treated as one source set: unless
+  `--keep-originals` is used, the descriptor and all validated companion tracks
+  are removed together. Any validation or conversion failure retains the full set
+- Archive members are rejected before conversion when paths escape the extraction
+  directory, links are present, or selected entries collide after name sanitisation
 - Temporary files are cleaned automatically, even on interruption
 
 ---

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -372,6 +372,138 @@ select_preferred_disc_candidates() {
     fi
 }
 
+is_safe_relative_path() {
+    local path="${1//\\//}"
+    [[ -n "$path" && "$path" != /* && ! "$path" =~ ^[[:alpha:]]: && "$path" != //* ]] || return 1
+    local part
+    IFS='/' read -r -a _path_parts <<< "$path"
+    for part in "${_path_parts[@]}"; do
+        [[ "$part" != ".." ]] || return 1
+    done
+}
+
+# Resolve each path component independently. This preserves safe subdirectories,
+# permits case-insensitive media layouts, and rejects ambiguous case-fold matches.
+resolve_descriptor_reference() {
+    local base_dir="$1" ref="${2//\\//}" current="$1" part match
+    is_safe_relative_path "$ref" || return 1
+    IFS='/' read -r -a _ref_parts <<< "$ref"
+    for part in "${_ref_parts[@]}"; do
+        [[ -n "$part" && "$part" != "." ]] || continue
+        if [[ -e "$current/$part" ]]; then
+            current="$current/$part"
+            continue
+        fi
+        local -a matches=()
+        while IFS= read -r -d '' match; do matches+=("$match"); done < <(
+            find "$current" -mindepth 1 -maxdepth 1 -iname "$part" -print0 2>/dev/null
+        )
+        (( ${#matches[@]} == 1 )) || return 1
+        current="${matches[0]}"
+    done
+    [[ -f "$current" ]] || return 1
+    printf '%s\n' "$current"
+}
+
+DESCRIPTOR_SOURCE_SET=()
+
+validate_descriptor_file() {
+    local descriptor="$1" ext="${1##*.}" base_dir stem line ref resolved
+    ext="${ext,,}"
+    base_dir="$(dirname "$descriptor")"
+    stem="${descriptor%.*}"
+    DESCRIPTOR_SOURCE_SET=("$descriptor")
+
+    case "$ext" in
+        cue)
+            local unsupported_audio=0 found=0
+            while IFS= read -r line; do
+                if [[ "$line" =~ ^[[:space:]]*FILE[[:space:]]+\"([^\"]+)\" ]]; then
+                    ref="${BASH_REMATCH[1]}"; found=1
+                    if ! is_safe_relative_path "$ref"; then
+                        log ERROR "❌ Unsafe path in CUE: $ref (required by $descriptor)"
+                        return 1
+                    fi
+                    if ! resolved="$(resolve_descriptor_reference "$base_dir" "$ref")"; then
+                        log ERROR "❌ Missing or ambiguous referenced file in CUE: $ref (required by $descriptor)"
+                        return 1
+                    fi
+                    DESCRIPTOR_SOURCE_SET+=("$resolved")
+                    case "${ref,,}" in
+                        *.mp3|*.ogg|*.opus|*.m4a|*.flac)
+                            if [[ "$ALLOW_UNVERIFIED_CUE_AUDIO" != true ]]; then
+                                log ERROR "❌ CUE references unsupported audio format: $ref"
+                                unsupported_audio=1
+                            fi ;;
+                    esac
+                fi
+            done < "$descriptor"
+            (( unsupported_audio == 0 )) || return 1
+            ;;
+        gdi)
+            local track_count=0
+            while IFS= read -r line; do
+                [[ "$line" =~ ^[[:space:]]*[0-9]+[[:space:]] ]] || continue
+                # GDI track filenames are the fifth field; quoted names may contain spaces.
+                ref="$(awk 'match($0,/^([^[:space:]]+[[:space:]]+){4}("[^"]+"|[^[:space:]]+)/){v=substr($0,RSTART,RLENGTH); sub(/^([^[:space:]]+[[:space:]]+){4}/,"",v); gsub(/^"|"$/,"",v); print v}' <<< "$line")"
+                [[ -n "$ref" ]] || { log ERROR "❌ Invalid GDI track entry: $line"; return 1; }
+                is_safe_relative_path "$ref" || { log ERROR "❌ Unsafe path in GDI: $ref"; return 1; }
+                resolved="$(resolve_descriptor_reference "$base_dir" "$ref")" || { log ERROR "❌ Missing or ambiguous GDI track: $ref"; return 1; }
+                DESCRIPTOR_SOURCE_SET+=("$resolved"); track_count=$((track_count + 1))
+            done < "$descriptor"
+            (( track_count > 0 )) || { log ERROR "❌ GDI contains no valid track entries: $descriptor"; return 1; }
+            ;;
+        ccd)
+            local companion
+            for companion in img sub; do
+                ref="$(basename "$stem").$companion"
+                resolved="$(resolve_descriptor_reference "$base_dir" "$ref")" || { log ERROR "❌ Missing CCD companion file: $ref"; return 1; }
+                DESCRIPTOR_SOURCE_SET+=("$resolved")
+            done
+            ;;
+        *) return 0 ;;
+    esac
+    log DEBUG "✅ Descriptor source-set validation passed: $descriptor"
+}
+
+validate_cue_file() { validate_descriptor_file "$1"; }
+
+validate_archive_member_paths() {
+    local member normalized part
+    for member in "$@"; do
+        normalized="${member//\\//}"
+        [[ "$normalized" == */ ]] && normalized="${normalized%/}"
+        [[ -z "$normalized" ]] && continue
+        if ! is_safe_relative_path "$normalized"; then
+            log ERROR "❌ Unsafe archive member path: $member"
+            return 1
+        fi
+    done
+}
+
+validate_archive_output_names() {
+    declare -A seen=()
+    local entry output key
+    for entry in "$@"; do
+        output="$(archive_entry_to_chd_name "$entry")"
+        key="${output,,}"
+        if [[ -n "${seen[$key]:-}" ]]; then
+            log ERROR "❌ Archive entries collide after output-name sanitisation: ${seen[$key]} and $entry -> $output"
+            return 1
+        fi
+        seen["$key"]="$entry"
+    done
+}
+
+validate_extracted_tree() {
+    local root="$1" link target
+    while IFS= read -r -d '' link; do
+        target="$(readlink -- "$link" 2>/dev/null || true)"
+        log ERROR "❌ Unsafe archive link rejected: ${link#"$root/"} -> $target"
+        return 1
+    done < <(find "$root" -type l -print0)
+}
+
 check_temp_storage "$TMPDIR"
 
 # ---------- chdman progress handling ----------
@@ -902,71 +1034,6 @@ verify_chds() {
     $all_verified && return 0 || return 1
 }
 
-validate_cue_file() {
-    local cue_file="$1"
-    local cuedir
-    cuedir="$(dirname "$cue_file")"
-    local cue_basename
-    cue_basename="$(basename "$cue_file")"
-    local missing=0
-    local unsupported_audio=0
-
-    declare -A file_map
-    while IFS= read -r -d '' f; do
-        file_map["${f,,}"]="$f"
-    done < <(find "$cuedir" -maxdepth 1 -type f -printf '%f\0')
-
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^[[:space:]]*FILE[[:space:]]+\"([^\"]+)\" ]]; then
-            local ref="${BASH_REMATCH[1]}"
-            local ref_norm="${ref//\\\\//}"
-            local ref_basename; ref_basename="$(basename "$ref_norm")"
-            local ref_lower="${ref_basename,,}"
-
-            [[ "$ref_lower" == "${cue_basename,,}" ]] && continue
-
-            if [[ "$ref_norm" == /* || "$ref_norm" == *".."* ]]; then
-                log WARN "⚠️ Skipping unsafe external path in CUE: $ref_basename"
-                continue
-            fi
-
-            if [[ -z "${file_map["$ref_lower"]:-}" ]]; then
-                log ERROR "❌ Missing referenced file in CUE: $ref_basename (required by $cue_file)"
-                missing=1
-                continue
-            fi
-
-            case "$ref_lower" in
-                *.wav)
-                    log DEBUG "🎵 CUE file references WAV audio track: $ref_basename"
-                    ;;
-                *.mp3|*.ogg|*.opus|*.m4a)
-                    if [[ "$ALLOW_UNVERIFIED_CUE_AUDIO" == true ]]; then
-                        log WARN "⚠️ CUE file references lossy/unsupported audio format, but override is enabled: $ref_basename"
-                    else
-                        log ERROR "❌ CUE file references lossy/unsupported audio format: $ref_basename"
-                        unsupported_audio=1
-                    fi
-                    ;;
-                *.flac)
-                    if [[ "$ALLOW_UNVERIFIED_CUE_AUDIO" == true ]]; then
-                        log WARN "⚠️ CUE file references FLAC audio track, but override is enabled: $ref_basename"
-                    else
-                        log ERROR "❌ CUE file references FLAC audio track: $ref_basename (lossless, but chdman input support is not yet confirmed)"
-                        unsupported_audio=1
-                    fi
-                    ;;
-            esac
-        fi
-    done < "$cue_file"
-
-    if (( missing == 0 && unsupported_audio == 0 )); then
-        log DEBUG "✅ CUE validation passed: $cue_file"
-        return 0
-    fi
-    return 1
-}
-
 detect_disc_type() {
     log DEBUG "DEBUG: Starting detection for: $1"
     local img="$1"
@@ -1002,18 +1069,19 @@ detect_disc_type() {
                     low=tolower(ref)
                     gsub(/\\/, "/", low)
                     # pick first "data-ish" file
-                    if (low ~ /\.(bin|iso|img|mdf)$/) { print ref; exit }
+                    if (low ~ /\.(bin|iso|img|mdf)$/) { print ref; selected=1; exit }
                     # otherwise remember first FILE as fallback
                     if (first == "") first = ref
                 }
-                END { if (first != "") print first }
+                END { if (!selected && first != "") print first }
             ' "$img"
         )"
 
         # Normalize Windows path separators
         raw_ref="${raw_ref//\\//}"
 
-        local sniff_candidate="$cue_dir/$raw_ref"
+        local sniff_candidate=""
+        sniff_candidate="$(resolve_descriptor_reference "$cue_dir" "$raw_ref" 2>/dev/null || true)"
 
         log DEBUG "DEBUG: CUE selected sniff candidate: [$raw_ref]"
         log DEBUG "DEBUG: Full resolved sniff path:     [$sniff_candidate]"
@@ -1089,10 +1157,10 @@ convert_disc_file() {
 
     [[ -n "$result_var" ]] && printf -v "$result_var" '%s' ""
 
-    # If it's a CUE, validate referenced files first
-    if [[ "${file,,}" == *.cue ]]; then
-        if ! validate_cue_file "$file"; then
-            log ERROR "❌ CUE validation failed: $file"
+    local file_ext="${file##*.}"; file_ext="${file_ext,,}"
+    if [[ "$file_ext" == "cue" || "$file_ext" == "gdi" || "$file_ext" == "ccd" ]]; then
+        if ! validate_descriptor_file "$file"; then
+            log ERROR "❌ Descriptor validation failed: $file"
             return 1
         fi
     fi
@@ -1243,6 +1311,7 @@ process_input() {
     local outdir
     outdir="$(dirname "$input_file")"
     local archive_entries=()
+    local archive_all_entries=()
     local archive_listing=""
     local archive_listing_exit=0
     local disc_files=()
@@ -1254,6 +1323,7 @@ process_input() {
     local temp_dir=""
     declare -A output_states=()
     declare -A output_temps=()
+    local direct_source_set=()
 
     _all_outputs_complete() {
         local expected state
@@ -1280,8 +1350,16 @@ process_input() {
             return 0
         fi
 
-        log INFO "🗑️ Removing original input file: $input_file"
-        rm -f -- "$input_file"
+        if (( ${#direct_source_set[@]} > 0 )); then
+            local source
+            for source in "${direct_source_set[@]}"; do
+                log INFO "🗑️ Removing validated descriptor source: $source"
+                rm -f -- "$source"
+            done
+        else
+            log INFO "🗑️ Removing original input file: $input_file"
+            rm -f -- "$input_file"
+        fi
     }
 
     if is_in_list "$ext" "${archive_exts[@]}"; then
@@ -1305,12 +1383,28 @@ process_input() {
         fi
 
         case "$ext" in
+            zip|rar) mapfile -t archive_all_entries <<< "$archive_listing" ;;
+            # The first Path field describes the archive itself. Member records
+            # begin after the separator in 7z's technical listing.
+            7z|7zip) mapfile -t archive_all_entries < <(awk 'seen && /^Path = /{print substr($0,8)} /^----------$/{seen=1}' <<< "$archive_listing") ;;
+        esac
+        if ! validate_archive_member_paths "${archive_all_entries[@]}"; then
+            log ERROR "❌ Archive path preflight failed: $input_file"
+            _return_failed_input
+            return 1
+        fi
+
+        case "$ext" in
             zip|rar) mapfile -t archive_entries < <(grep -Ei "$ext_regex" <<< "$archive_listing" || true) ;;
-            7z|7zip) mapfile -t archive_entries < <(awk -v IGNORECASE=1 -v re="$ext_regex" '/^Path = /{p=substr($0,8); if(p~re) print p}' <<< "$archive_listing") ;;
+            7z|7zip) mapfile -t archive_entries < <(awk -v IGNORECASE=1 -v re="$ext_regex" 'seen && /^Path = /{p=substr($0,8); if(p~re) print p} /^----------$/{seen=1}' <<< "$archive_listing") ;;
         esac
 
         if [[ ${#archive_entries[@]} -gt 0 ]]; then
             mapfile -t archive_entries < <(select_preferred_disc_candidates "${archive_entries[@]}")
+            if ! validate_archive_output_names "${archive_entries[@]}"; then
+                _return_failed_input
+                return 1
+            fi
             log DEBUG "📀 Selected ${#archive_entries[@]} preferred disc descriptor(s) from archive: $(basename "$input_file")"
             for entry in "${archive_entries[@]}"; do
                 local expected_chd
@@ -1332,13 +1426,19 @@ process_input() {
         return 0
     fi
 
-    # If this input is a CUE, validate it even if CHDs already exist.
-    # Broken CUEs should count as an input failure (even if we can skip conversion).
-    if [[ "$ext" == "cue" ]]; then
-        if ! validate_cue_file "$input_file"; then
-            log ERROR "❌ CUE validation failed (input considered failed): $input_file"
+    # Direct descriptors own a complete validated source set. On success, all
+    # members are removed together; on any failure, every source is retained.
+    if [[ "$ext" == "cue" || "$ext" == "gdi" || "$ext" == "ccd" ]]; then
+        if ! validate_descriptor_file "$input_file"; then
+            log ERROR "❌ Descriptor validation failed (input considered failed): $input_file"
             input_failed=true
+        else
+            direct_source_set=("${DESCRIPTOR_SOURCE_SET[@]}")
         fi
+    fi
+    if [[ "$input_failed" == true ]]; then
+        _return_failed_input
+        return 1
     fi
 
     # Establish one authoritative state for every expected output.
@@ -1402,9 +1502,12 @@ process_input() {
                 return 1
             fi
 
-            log DEBUG "🧹 Flushing extraction buffers to free up RAM..."
-            sync
-            sleep 1
+            if ! validate_extracted_tree "$temp_dir"; then
+                input_failed=true
+                cleanup_temp_dir_now "$temp_dir"
+                _return_failed_input
+                return 1
+            fi
 
             read -r -a disc_find_expr <<< "$(build_find_expr "${disc_exts[@]}")"
             mapfile -d '' -t disc_files < <(find "$temp_dir" -type f \( "${disc_find_expr[@]}" \) -print0)
@@ -1458,6 +1561,15 @@ process_input() {
         for entry in "${archive_entries[@]}"; do
             local extracted="$temp_dir/$entry"
             [[ -f "$extracted" ]] || continue
+
+            local extracted_ext="${extracted##*.}"; extracted_ext="${extracted_ext,,}"
+            if [[ "$extracted_ext" == "cue" || "$extracted_ext" == "gdi" || "$extracted_ext" == "ccd" ]]; then
+                if ! validate_descriptor_file "$extracted"; then
+                    log ERROR "❌ Extracted descriptor validation failed: $entry"
+                    input_failed=true
+                    continue
+                fi
+            fi
 
             local chd_name chd_base
             chd_name="$(archive_entry_to_chd_name "$entry")"   # e.g. "CD1 - Game.chd"

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -12,7 +12,6 @@ RECURSIVE=false
 DRY_RUN=false
 ALLOW_UNVERIFIED_CUE_AUDIO=false
 INPUT_DIR=""
-IS_RAM_DISK=false
 RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
 CHDMAN_MSG_LEVEL="${CHDMAN_MSG_LEVEL:-DEBUG}"
 case "${CHDMAN_MSG_LEVEL^^}" in
@@ -330,8 +329,6 @@ check_temp_storage() {
         log WARN "⚠️ $tmp_dir is a RAM disk (tmpfs). Extracted ISOs will consume physical RAM!"
         log WARN "💡 Available space in RAM disk: $tmp_limit"
 
-        # Force thread reduction if we are in a RAM disk
-        IS_RAM_DISK=true
     fi
 }
 
@@ -416,10 +413,10 @@ validate_descriptor_file() {
 
     case "$ext" in
         cue)
-            local unsupported_audio=0 found=0
+            local unsupported_audio=0
             while IFS= read -r line; do
                 if [[ "$line" =~ ^[[:space:]]*FILE[[:space:]]+\"([^\"]+)\" ]]; then
-                    ref="${BASH_REMATCH[1]}"; found=1
+                    ref="${BASH_REMATCH[1]}"
                     if ! is_safe_relative_path "$ref"; then
                         log ERROR "❌ Unsafe path in CUE: $ref (required by $descriptor)"
                         return 1
@@ -465,8 +462,6 @@ validate_descriptor_file() {
     esac
     log DEBUG "✅ Descriptor source-set validation passed: $descriptor"
 }
-
-validate_cue_file() { validate_descriptor_file "$1"; }
 
 validate_archive_member_paths() {
     local member normalized part
@@ -1544,8 +1539,7 @@ process_input() {
 
     if [[ "$DRY_RUN" == true ]]; then
         for disc in "${disc_files[@]}"; do
-            local dry_result=""
-            convert_disc_file "$disc" "$outdir" "" dry_result || input_failed=true
+            convert_disc_file "$disc" "$outdir" || input_failed=true
         done
 
         # Dry-run: also show M3U intent (if this looks like a multi-disc set)

--- a/chdtool.sh
+++ b/chdtool.sh
@@ -1188,16 +1188,12 @@ convert_disc_file() {
     # Decide CD vs DVD and pick subcommand + icon
     local disc_type
     disc_type="$(detect_disc_type "$file")"
-    local hunk_size=2448 #Default
-
     local subcmd icon
     case "$disc_type" in
         ps2)
-            # PS2 is the special case; Hunk is ALWAYS 2048, but command depends on size
             log DEBUG "PS2 image detected, checking size to determine if DVD structure is likely"
             local sz
             sz=$(get_file_size "$file")
-            hunk_size=2048
             if (( sz >= 1000000000 )); then
                 log DEBUG "Large PS2 image suggests DVD structure, CHDMAN_HAS_CREATEDVD=$CHDMAN_HAS_CREATEDVD"
                 if [[ "$CHDMAN_HAS_CREATEDVD" == true ]]; then
@@ -1218,7 +1214,6 @@ convert_disc_file() {
             log DEBUG "DVD detected, CHDMAN_HAS_CREATEDVD=$CHDMAN_HAS_CREATEDVD"
             if [[ "$CHDMAN_HAS_CREATEDVD" == true ]]; then
                 subcmd="createdvd"
-                hunk_size=2048 # DVD-ROM and PS2/PSP discs use standard 2K data sectors
                 icon="📀"
             else
                 log WARN "⚠️ Detected DVD image but this chdman lacks 'createdvd'. Skipping: $file"
@@ -1228,44 +1223,52 @@ convert_disc_file() {
         ps1|dreamcast|segacd|saturn|cd)
             log DEBUG "CD-type image detected, using createcd"
             subcmd="createcd"
-            hunk_size=2448 # CD-ROMs use 2352-byte raw sectors but chdman createcd expects 2448 to include subchannel data for full disc preservation
             icon="💿"
             ;;
         *)
             log WARN "⚠️ Unknown disc type detected, defaulting to CD settings: $file"
             subcmd="createcd"
-            hunk_size=2448
             icon="💿"
             ;;
     esac
 
     log INFO "$icon Detected $disc_type image → using chdman $subcmd"
 
-    # Calculate safe threads: ~one thread per 2GB RAM (for CDs) or 4GB RAM (for DVDs)
-    local total_ram_mb=$(( $(awk '/MemTotal|SwapTotal/{sum+=$2} END{print sum}' /proc/meminfo) / 1024 ))
-    local available_ram=$total_ram_mb
-
-    if [[ "$IS_RAM_DISK" == true ]]; then
-        local iso_size_mb=$(( $(stat -c%s "$file") / 1048576 ))
-        (( available_ram = total_ram_mb - iso_size_mb))
-        log DEBUG "📉 RAM disk detected. Adjusting available RAM for chdman to ${available_ram}MB"
-    fi
-
+    # Base concurrency on currently available physical memory. Swap is not
+    # interchangeable with RAM for compression and can cause severe thrashing.
+    local available_ram
+    available_ram=$(( $(awk '/^MemAvailable:/{print $2; found=1} END{if(!found) print 0}' /proc/meminfo 2>/dev/null) / 1024 ))
+    (( available_ram < 1 )) && available_ram=1024
     local cpu_cores
-    cpu_cores=$(nproc)
+    cpu_cores=$(nproc 2>/dev/null || echo 1)
+    (( cpu_cores < 1 )) && cpu_cores=1
     local ram_per_thread=2048   # Default for CDs
 
     if [[ "$subcmd" == "createdvd" ]]; then
         ram_per_thread=4096  # 4GB floor for DVDs (LZMA is a beast here)
     fi
 
-    # Calculate threads based on RAM (aiming for ~3GB per thread)
+    # Calculate threads from available RAM, then apply the explicit override.
     local threads=$(( available_ram / ram_per_thread ))
     (( threads < 1 )) && threads=1
     (( threads > cpu_cores )) && threads=$cpu_cores
+    if [[ -n "${CHDMAN_THREADS:-}" ]]; then
+        [[ "$CHDMAN_THREADS" =~ ^[1-9][0-9]*$ ]] || { log ERROR "❌ CHDMAN_THREADS must be a positive integer"; return 1; }
+        threads="$CHDMAN_THREADS"
+        (( threads > cpu_cores )) && threads=$cpu_cores
+    fi
+
+    local -a chdman_args=("$subcmd" -np "$threads")
+    if [[ -n "${CHDMAN_HUNK_SIZE:-}" ]]; then
+        [[ "$CHDMAN_HUNK_SIZE" =~ ^[1-9][0-9]*$ ]] || { log ERROR "❌ CHDMAN_HUNK_SIZE must be a positive integer"; return 1; }
+        chdman_args+=(-hs "$CHDMAN_HUNK_SIZE")
+    fi
+    chdman_args+=(-i "$file")
 
     if [[ "$DRY_RUN" == true ]]; then
-        log INFO "🧪 (dry-run) Would run: ${CHDMAN_BIN:-chdman} $subcmd -np $threads -i \"$file\" -o a unique temporary CHD beside \"$chd_path\""
+        local command_preview
+        printf -v command_preview '%q ' "${CHDMAN_BIN:-chdman}" "${chdman_args[@]}" -o "<unique temporary CHD beside $chd_path>"
+        log INFO "🧪 (dry-run) Would run: ${command_preview% }"
         return 0
     fi
 
@@ -1282,16 +1285,17 @@ convert_disc_file() {
     track_temp_file "$tmp_chd"
     [[ -n "$result_var" ]] && printf -v "$result_var" '%s' "$tmp_chd"
     log INFO "🔧 Converting: $file -> $tmp_chd"
+    local -a command=("${CHDMAN_BIN:-chdman}" "${chdman_args[@]}" -o "$tmp_chd")
 
     if [[ -t 2 && "${PROGRESS_STYLE:-$PROGRESS_STYLE_DEFAULT}" != "none" ]]; then
-        if ! PHASE_DEFAULT="Converting" stdbuf -oL -eL "${CHDMAN_BIN:-chdman}" "$subcmd" -np "$threads" -hs "$hunk_size" -i "$file" -o "$tmp_chd" 2>&1 | _chdman_progress_filter; then
+        if ! PHASE_DEFAULT="Converting" stdbuf -oL -eL "${command[@]}" 2>&1 | _chdman_progress_filter; then
             log ERROR "❌ chdman $subcmd failed for: $file"
             cleanup_temp_file_now "$tmp_chd"
             cleanup_temp_dir_now "$tmp_dir"
             return 1
         fi
     else
-        if ! "${CHDMAN_BIN:-chdman}" "$subcmd" -np "$threads" -hs "$hunk_size" -i "$file" -o "$tmp_chd"; then
+        if ! "${command[@]}"; then
             log ERROR "❌ chdman $subcmd failed for: $file"
             cleanup_temp_file_now "$tmp_chd"
             cleanup_temp_dir_now "$tmp_dir"
@@ -1299,8 +1303,6 @@ convert_disc_file() {
         fi
     fi
 
-    sync
-    sleep 1
     return 0
 }
 
@@ -1542,7 +1544,8 @@ process_input() {
 
     if [[ "$DRY_RUN" == true ]]; then
         for disc in "${disc_files[@]}"; do
-            log INFO "🧪 (dry-run) Would convert: $disc -> $outdir/$(basename "${disc%.*}").chd"
+            local dry_result=""
+            convert_disc_file "$disc" "$outdir" "" dry_result || input_failed=true
         done
 
         # Dry-run: also show M3U intent (if this looks like a multi-disc set)
@@ -1552,6 +1555,7 @@ process_input() {
             maybe_generate_m3u_for "$chd_base" "$outdir"
         fi
         
+        [[ "$input_failed" == true ]] && { _return_failed_input; return 1; }
         return 0
     fi
 

--- a/tests/bin/chdman
+++ b/tests/bin/chdman
@@ -22,6 +22,7 @@ case "$1" in
     exit 0
     ;;
   createcd|createdvd)
+    [[ -n "${CHDMAN_ARGS_LOG:-}" ]] && printf '%s\n' "$*" >> "$CHDMAN_ARGS_LOG"
     input=""
     output=""
     while [[ $# -gt 0 ]]; do

--- a/tests/test_resource_handling.sh
+++ b/tests/test_resource_handling.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${SCRIPT:-$REPO_ROOT/chdtool.sh}"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+export PATH="$REPO_ROOT/tests/bin:$PATH" PROGRESS_STYLE=none LOG_DEST=console LOG_LEVEL_THRESHOLD=ERROR
+
+mkdir "$FIX/default" "$FIX/override" "$FIX/dry"
+: > "$FIX/default/Default.iso"
+CHDMAN_ARGS_LOG="$FIX/default.args" bash "$SCRIPT" --keep-originals "$FIX/default" >/dev/null
+! grep -q -- ' -hs ' "$FIX/default.args" || { echo "FAIL: default conversion forced a hunk size" >&2; exit 1; }
+
+: > "$FIX/override/Override.iso"
+CHDMAN_ARGS_LOG="$FIX/override.args" CHDMAN_THREADS=999999 CHDMAN_HUNK_SIZE=8192 \
+  bash "$SCRIPT" --keep-originals "$FIX/override" >/dev/null
+grep -q -- '-hs 8192' "$FIX/override.args" || { echo "FAIL: hunk override missing" >&2; exit 1; }
+threads="$(sed -n 's/.*-np \([0-9][0-9]*\).*/\1/p' "$FIX/override.args")"
+(( threads >= 1 && threads <= $(nproc) )) || { echo "FAIL: thread override was not CPU-bounded" >&2; exit 1; }
+
+: > "$FIX/dry/Dry.iso"
+dry_output="$(LOG_LEVEL_THRESHOLD=INFO CHDMAN_THREADS=1 CHDMAN_HUNK_SIZE=4096 bash "$SCRIPT" --dry-run "$FIX/dry" 2>&1)"
+grep -q -- '-np 1 -hs 4096 -i' <<< "$dry_output" || { echo "FAIL: dry-run command omitted effective options" >&2; exit 1; }
+
+echo "PASS: resource selection and chdman command construction"

--- a/tests/test_security_validation.sh
+++ b/tests/test_security_validation.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${SCRIPT:-$REPO_ROOT/chdtool.sh}"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+
+export PATH="$REPO_ROOT/tests/bin:$PATH"
+export PROGRESS_STYLE=none LOG_DEST=console LOG_LEVEL_THRESHOLD=ERROR
+
+expect_failure() {
+  local dir="$1"
+  set +e
+  bash "$SCRIPT" "$dir" >/dev/null 2>&1
+  local status=$?
+  set -e
+  [[ $status -eq 2 ]] || { echo "FAIL: $dir returned $status, expected 2" >&2; exit 1; }
+}
+
+# Safe nested references resolve component-by-component and successful direct
+# descriptor cleanup removes the complete validated source set.
+mkdir -p "$FIX/nested/Tracks"
+printf 'FILE "tracks/DATA.BIN" BINARY\n  TRACK 01 MODE1/2352\n' > "$FIX/nested/Game.cue"
+: > "$FIX/nested/Tracks/data.bin"
+bash "$SCRIPT" "$FIX/nested" >/dev/null
+[[ -f "$FIX/nested/Game.chd" && ! -e "$FIX/nested/Game.cue" && ! -e "$FIX/nested/Tracks/data.bin" ]] || {
+  echo "FAIL: nested CUE conversion or source-set cleanup" >&2; exit 1;
+}
+
+mkdir -p "$FIX/parent" "$FIX/absolute"
+printf 'FILE "../outside.bin" BINARY\n' > "$FIX/parent/Unsafe.cue"
+: > "$FIX/outside.bin"
+printf 'FILE "/tmp/outside.bin" BINARY\n' > "$FIX/absolute/Unsafe.cue"
+expect_failure "$FIX/parent"
+expect_failure "$FIX/absolute"
+
+mkdir -p "$FIX/gdi" "$FIX/ccd"
+printf '1\n1 0 4 2352 missing.bin 0\n' > "$FIX/gdi/Missing.gdi"
+printf '[CloneCD]\nVersion=3\n' > "$FIX/ccd/Missing.ccd"
+: > "$FIX/ccd/Missing.img"
+expect_failure "$FIX/gdi"
+expect_failure "$FIX/ccd"
+
+# Both selected entries map to "A - B.chd" after sanitisation.
+mkdir -p "$FIX/collision/build"
+: > "$FIX/collision/build/A:B.iso"
+: > "$FIX/collision/build/A?B.iso"
+(cd "$FIX/collision/build" && zip -q ../collision.zip ./*)
+expect_failure "$FIX/collision"
+
+# A traversal member must be rejected from the listing before extraction.
+mkdir -p "$FIX/traversal/build"
+: > "$FIX/traversal/escape.iso"
+(cd "$FIX/traversal/build" && zip -q ../traversal.zip ../escape.iso)
+expect_failure "$FIX/traversal"
+
+echo "PASS: descriptor and archive security validation"


### PR DESCRIPTION
## Summary

- harden CUE, GDI, and CCD descriptor source-set validation
- reject unsafe archive paths, links, and sanitised output-name collisions
- define transactional cleanup for direct descriptor companion files
- use available physical memory for bounded `chdman` thread selection
- remove forced hunk sizes, global `sync` calls, and fixed sleeps
- add documented thread and hunk-size overrides

## Why

Descriptor references were resolved too loosely, companion files were not consistently validated, and archives could reach extraction without sufficient path and collision preflight. Resource selection also counted swap as usable compression memory and forced hunk sizes without measured justification.

The new validation builds a safe, complete source set before conversion or cleanup. Resource defaults now defer format-specific hunk sizing to `chdman` and select conservative concurrency from currently available physical memory.

## Impact

Unsafe, incomplete, or ambiguous descriptor/archive inputs now fail before `chdman` runs and retain their originals. Successful direct descriptor conversions remove the validated source set together unless `--keep-originals` is enabled.

Advanced users can set `CHDMAN_THREADS` and `CHDMAN_HUNK_SIZE`; thread counts remain CPU-bounded. Dry-run output reports the effective direct-input command.

## Validation

- `shellcheck chdtool.sh tests/*.sh tests/bin/*`
- complete Bash regression suite
- focused descriptor/archive security regressions
- focused resource-selection and command-construction regressions

Fixes #32.
Fixes #31.
