### PR TITLE
docs: document release procedure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing to **chdscript**! 🎉
+Thanks for your interest in contributing to **chdtool**! 🎉
 
 ## How to Contribute
 
@@ -22,7 +22,7 @@ Thanks for your interest in contributing to **chdscript**! 🎉
    git push origin feature/my-new-feature
    ```
 
-4. **Open a Pull Request** against `main`.
+4. **Open a Pull Request** against `develop`.
 
 ## Coding Guidelines
 
@@ -47,6 +47,9 @@ Bump version numbers when you:
 - `MAJOR`: Break backward compatibility
 - `MINOR`: Add new functionality in a backward-compatible manner
 - `PATCH`: Fix bugs or make small improvements
+
+Maintainers should follow the complete [release procedure](RELEASING.md) when
+preparing, tagging, publishing, and verifying a release.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ script. Verify downloads with the published checksum file:
 sha256sum --check SHA256SUMS
 ```
 
+Maintainers should use the documented [release procedure](RELEASING.md) rather
+than creating tags or assets manually.
+
 ---
 
 ## 🛠️ Design Goals

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,145 @@
+# Release procedure
+
+This project uses a gitflow-style release process. Development is integrated on
+`develop`; releases are made from `main` and triggered by tags named
+`vMAJOR.MINOR.PATCH`.
+
+## Prerequisites
+
+- Push access to `lloydsmart/chdtool`
+- Permission to merge into `develop` and `main`
+- GitHub Actions permission to create pull requests
+- Bash, Make, ShellCheck, `tar`, `gzip`, `zip`, `unzip`, and `sha256sum`
+- `git-cliff` when generating changelogs locally
+
+Start with a clean, current checkout:
+
+```bash
+git switch develop
+git pull --ff-only origin develop
+git status --short
+```
+
+The final command should print nothing.
+
+## 1. Choose and set the version
+
+Choose the next version according to Semantic Versioning. Create a release
+branch from `develop`:
+
+```bash
+git switch -c release/0.2.5
+```
+
+Update `CHDTOOL_VERSION` near the top of `chdtool.sh`. Confirm that the CLI
+reports the intended value:
+
+```bash
+./chdtool.sh --version
+```
+
+The release workflow rejects a tag whose version does not match this value.
+
+## 2. Run the preflight checks
+
+Run the same functional and shell checks used by the release workflow:
+
+```bash
+make test
+shellcheck chdtool.sh scripts/*.sh tests/*.sh tests/bin/*
+```
+
+When `actionlint` and `markdownlint-cli2` are available, also run:
+
+```bash
+actionlint
+npx --yes markdownlint-cli2 "**/*.md" "#CHANGELOG.md" \
+  "#CHANGELOG_RELEASE.md" "#LICENSE.md"
+```
+
+Build and validate the release assets locally:
+
+```bash
+make package VERSION=0.2.5
+(cd dist && sha256sum --check SHA256SUMS)
+tar -tzf dist/chdtool-v0.2.5.tar.gz
+unzip -Z1 dist/chdtool-v0.2.5.zip
+```
+
+Both archives must contain exactly one top-level `chdtool-v0.2.5` directory
+with these files:
+
+- `chdtool`
+- `README.md`
+- `LICENSE.md`
+- `CHANGELOG.md`
+
+The `dist/` directory is rebuilt from scratch by the packaging command.
+
+## 3. Merge the release change
+
+Commit the version change, push the release branch, and open a pull request into
+`develop`:
+
+```bash
+git add chdtool.sh
+git commit -m "chore: prepare v0.2.5"
+git push -u origin release/0.2.5
+```
+
+Merge only after all required checks pass. Then open and merge a pull request
+from `develop` into `main`. Do not tag the release branch or an unmerged commit.
+
+## 4. Tag and publish
+
+Update local `main` and verify the version one final time:
+
+```bash
+git switch main
+git pull --ff-only origin main
+./chdtool.sh --version
+git status --short
+```
+
+Create an annotated tag on that exact commit and push only the tag:
+
+```bash
+git tag -a v0.2.5 -m "Release v0.2.5"
+git push origin v0.2.5
+```
+
+Pushing the tag starts the `Release` workflow. It:
+
+1. runs the complete test suite and ShellCheck;
+2. generates release notes with git-cliff;
+3. builds reproducible `.tar.gz` and `.zip` archives;
+4. validates their exact contents;
+5. creates `SHA256SUMS` and verifies every checksum;
+6. publishes the GitHub release and assets; and
+7. opens a pull request to update `CHANGELOG.md` on `main`.
+
+## 5. Verify and synchronise
+
+On the GitHub release page, confirm:
+
+- the release is attached to the intended tag and commit;
+- the release notes are present;
+- `chdtool`, both archives, and `SHA256SUMS` are attached; and
+- downloaded assets pass `sha256sum --check SHA256SUMS`.
+
+Merge the automated changelog pull request after its checks pass. Finally,
+merge or fast-forward `main` back into `develop` so both long-lived branches
+contain the release tag's code and generated changelog.
+
+## Failure handling
+
+- If preflight checks or local packaging fail, fix them on the release branch;
+  do not tag.
+- If the tag workflow fails before publishing a release, inspect the failed job,
+  fix the problem through the normal branch and pull-request flow, then decide
+  whether the unused tag can be deleted and recreated.
+- Never move or reuse a tag after a GitHub release has been published. Correct a
+  published release with a new patch version.
+- Do not upload hand-built replacement assets to an automated release; rerun a
+  corrected workflow under a new version so provenance and checksums remain
+  consistent.


### PR DESCRIPTION
## Summary

- add a dedicated maintainer release runbook
- document version selection, preflight checks, local artifact validation, and tagging
- explain the automated release workflow, checksum verification, changelog PR, and branch synchronisation
- provide failure-handling guidance, including published-tag immutability
- correct the contributor guide's project name and change its PR target to `develop`
- link the runbook from the README and contributor documentation

## Why

Release automation is now strict and reproducible, but maintainers still need a clear human procedure for preparing the version, promoting `develop` to `main`, tagging the correct commit, verifying published assets, and synchronising the long-lived branches afterward.

## Validation

- markdownlint on `README.md`, `CONTRIBUTING.md`, and `RELEASING.md`
- `git diff --check`