### PR TITLE
chore: prepare v0.3.0

### DIFF
--- a/chdtool.sh
+++ b/chdtool.sh
@@ -6,7 +6,7 @@ script_start_time=$(date +%s)
 shopt -s nullglob
 shopt -s extglob
 
-CHDTOOL_VERSION="0.2.4"
+CHDTOOL_VERSION="0.3.0"
 PROGRAM_NAME="$(basename -- "$0")"
 USAGE="Usage: $PROGRAM_NAME [options] [--] <input directory>"
 


### PR DESCRIPTION
## Summary

- bump the embedded `CHDTOOL_VERSION` from `0.2.4` to `0.3.0`
- prepare the next minor release after the validation, regression, CLI, logging, packaging, and documentation improvements merged since v0.2.5

## Release process

This is the release-preparation PR into `develop`. After it merges and all checks pass, `develop` must be promoted to `main`. Tag `v0.3.0` only on the resulting merged `main` commit; pushing that tag will trigger the existing Release workflow to test, package, checksum, publish, and generate the changelog PR.

## Preflight validation

- `make test`
- ShellCheck across `chdtool.sh`, packaging scripts, tests, and stubs
- `make package VERSION=0.3.0` using an isolated distribution directory
- `sha256sum --check SHA256SUMS`
- exact `.tar.gz` and `.zip` manifest inspection
- `chdtool.sh --version` reports `0.3.0`
- `git diff --check`