### PR TITLE
docs: require protection for release branches

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -133,6 +133,10 @@ a backport pull request from `main` into `develop` so both long-lived branches
 contain the release merge, tag history, and generated changelog. Resolve the
 backport before starting further release work.
 
+Both `main` and `develop` must have GitHub branch protection enabled, with branch
+deletion and force pushes disabled. This prevents GitHub's automatic head-branch
+deletion from removing `main` after the backport pull request is merged.
+
 ## Failure handling
 
 - If preflight checks or local packaging fail, fix them on the release branch;


### PR DESCRIPTION
## Summary

- document that `main` and `develop` must be protected against deletion and force pushes
- retain the direct `main` → `develop` release backport workflow
- prevent GitHub's automatic head-branch cleanup from deleting either permanent branch

The corresponding minimal branch-protection rules have now been enabled for both branches, including administrator enforcement.

## Validation

- `npx --yes markdownlint-cli2 RELEASING.md`
- `git diff --check`